### PR TITLE
Geonode - Make registry for NGINX configurable

### DIFF
--- a/charts/geonode/v0.4.1/templates/_helpers.tpl
+++ b/charts/geonode/v0.4.1/templates/_helpers.tpl
@@ -40,6 +40,23 @@ Also, we can't use a single if because lazy evaluation is not an option
 {{- end -}}
 
 {{/*
+Return the proper nginx image name
+*/}}
+{{- define "nginx.image" -}}
+{{- $repositoryName := "library/nginx" -}}
+{{- $tag := "1.17-alpine" | toString -}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" "docker.io" $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" "docker.io" $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Derive shared secret name for this release
 Must only depends on global values
 */}}

--- a/charts/geonode/v0.4.1/templates/deployment.yaml
+++ b/charts/geonode/v0.4.1/templates/deployment.yaml
@@ -85,7 +85,7 @@ spec:
           {{- end }}
 
         - name: {{ template "geonode.fullname" . }}-nginx
-          image: nginx:1.17.2-alpine
+          image: {{ template "nginx.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
In some clusters you're not allowed to use Docker Hub, which currently makes installing this Helm Chart impossible. I've modified the geonode-nginx container to make the registry configurable using the value from `.Values.global.imageRegistry`

Signed-off-by: Joost Buskermolen <joost@buskervezel.nl>