### PR TITLE
Don't create secret when existingSecret is set

### DIFF
--- a/charts/geonode/v0.4.1/templates/secrets.yaml
+++ b/charts/geonode/v0.4.1/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,7 +10,6 @@ metadata:
     heritage: {{ .Release.Service | quote }}
 type: Opaque
 data:
-{{- if not .Values.global.existingSecret }}
   ## Django related secret
   # Django Admin User
   admin-user: {{ .Values.global.adminUser | b64enc | quote }}


### PR DESCRIPTION
In the current situation a new secret will be created regardless of having an `existingSecret` or not. This causes issues as Helm still tries to create the secret, while it is already manually created. This is especially troublesome when using CD tools like ArgoCD, as the secret gets replaced with an empty one by Helm during a sync.

This PR mitigates this issue by ignoring the `secrets.yaml` template whenever `existingSecret` is set