### PR TITLE
Update rabbitmq version to 10.1.10

### DIFF
--- a/charts/geonode/v0.4.1/Chart.yaml
+++ b/charts/geonode/v0.4.1/Chart.yaml
@@ -33,7 +33,7 @@ dependencies:
       - map-backend
       - geoserver
   - name: rabbitmq
-    version: 7.6.6
+    version: 10.1.10
     repository: "https://charts.bitnami.com/bitnami"
     condition: rabbitmq.enabled
     tags:


### PR DESCRIPTION
rabbitmq version 7.6.6 is no longer a valid version. Update to 10.1.10 to allow "Lint and Test Charts" check to complete.

More information here: [https://github.com/kartoza/charts/runs/7089141095?check_suite_focus=true](https://github.com/kartoza/charts/runs/7089141095?check_suite_focus=true)