### PR TITLE
add security context for non root user

### DIFF
--- a/charts/geoserver/v0.3.3/templates/deployment.yaml
+++ b/charts/geoserver/v0.3.3/templates/deployment.yaml
@@ -37,6 +37,10 @@ spec:
         {{- (tpl . $) | nindent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{ . | toYaml | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ template "geoserver.fullname" . }}
           image: {{ template "geoserver.image" . }}

--- a/charts/geoserver/v0.3.3/values.yaml
+++ b/charts/geoserver/v0.3.3/values.yaml
@@ -29,6 +29,14 @@ extraPodEnv: |
   - name: MAXIMUM_MEMORY
     value: "4G"
 
+
+# newer versions of geoserver docker image do not run as route, need to specify the security context to avoid a persmissions denied error.
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 10001
+  fsGroup: 10001
+  fsGroupChangePolicy: "OnRootMismatch"
+
 # This will be evaluated as pod spec
 extraPodSpec: |
 #  nodeSelector:


### PR DESCRIPTION
This PR would add a security context section to the GeoServer Pod to take into account of the fact that newer docker images of GeoServer runs with a non root user and thus encounters a permissions error when accessing mounted volumes.