### PR TITLE
Update GitHub CICD pipelines

### DIFF
--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -1,36 +1,38 @@
 name: Lint and Test Charts
 
-on: pull_request
+on:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   lint-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Fetch history
         run: git fetch --prune --unshallow
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
           version: 'v3.4.0'
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.7
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.0.1
+        uses: helm/chart-testing-action@v2.6.0
 
       - name: Set up nix
-        uses: cachix/install-nix-action@v12
+        uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 
       - name: Set up nix store cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/nix-closure
           # Build inputs are:
@@ -46,12 +48,13 @@ jobs:
         run: |
           if [[ -f /tmp/nix-closure/nix-shell.closure ]]; then
             nix-store --import --option require-sigs false < /tmp/nix-closure/nix-shell.closure
-            echo "::set-output name=use-cache::true"
+            echo "use-cache=true" >> $GITHUB_OUTPUT
           fi
       - run: |
           nix-env -f '<nixpkgs>' -iA pkgs.direnv
           nix-build
           nix-shell --run "direnv allow"
+
       - name: Store nix derivation cache
         run: |
           DERIVATION=$(readlink result)
@@ -65,7 +68,7 @@ jobs:
         run: |
           changed=$(ct list-changed)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "use-cache=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)
@@ -74,9 +77,9 @@ jobs:
         run: ct lint
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@v1.5.0
         with:
-          node_image: "kindest/node:v1.19.1"
+          node_image: "kindest/node:v1.29.0"
         # Only build a kind cluster if there are chart changes to test.
         if: steps.list-changed.outputs.changed == 'true'
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
The GeoServer HELM chart cannot be updated because of failures in CICD pipelines.
The pipeline called "Lint and Test Charts" has outdated actions, so the `direnv` tool didn't work properly.
Besides that GitHub provides such a warning message:
```
The following actions use node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, azure/setup-helm@v1, actions/setup-python@v2, helm/kind-action@v1.2.0. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```

So to avoid further errors versions of the given actions were updated to the latest.

Manual execution of a `Lint and Test Charts` pipeline is also enabled to let folks re-run failed CI pipelines when logs are not available anymore.

You can check how does the pipeline work now in my fork: 
https://github.com/filatovw/charts/actions/runs/7277666015