### PR TITLE
default GeoServer version is 2.24.1

### DIFF
--- a/charts/geoserver/v0.3.3/values.yaml
+++ b/charts/geoserver/v0.3.3/values.yaml
@@ -1,7 +1,7 @@
 image:
   registry: docker.io
   repository: kartoza/geoserver
-  tag: "2.21.0"
+  tag: "2.24.1"
   pullPolicy: IfNotPresent
 
 geoserverDataDir: /opt/geoserver/data_dir


### PR DESCRIPTION
As geoserver v0.3.3 was never released it is better to start using it with the latest version of a geoserver image available.

I tested it on EKS cluster v1.23 - works like a charm out of the box.

Please propagate latest changes to the `main` branch to make helm chart publicly available.