### PR TITLE
Release workflow fix

### DIFF
--- a/charts/geonode/v0.4.1/Chart.yaml
+++ b/charts/geonode/v0.4.1/Chart.yaml
@@ -33,7 +33,7 @@ dependencies:
       - map-backend
       - geoserver
   - name: rabbitmq
-    version: 7.6.6
+    version: 12.6.1
     repository: "https://charts.bitnami.com/bitnami"
     condition: rabbitmq.enabled
     tags:

--- a/charts/nextcloud/v2.0.0/Chart.yaml
+++ b/charts/nextcloud/v2.0.0/Chart.yaml
@@ -30,6 +30,6 @@ dependencies:
     repository: "file://../../postgis/v0.2.4"
     condition: postgis.enabled
   - name: redis
-    version: 14.6.1
+    version: 18.6.1
     repository: "https://charts.bitnami.com/bitnami"
     condition: redis.enabled

--- a/charts/qgis-server/v0.2.1/Chart.yaml
+++ b/charts/qgis-server/v0.2.1/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: qgis-server
 version: 0.2.1
-appVersion: 3.14
+appVersion: "3.14"
 description: Chart for QGIS-Server
 keywords:
   - QGIS


### PR DESCRIPTION
- geonode: bitnami rabbitmq helm chart is longer accessible. Replaced it with the latest version
- nextcloud: same for redis
- qgis-server: Helm chart app version should be a string, but yaml encoder treats `<X>.<Y>` as a float. Wrapped it with quotes to overcome this issue.